### PR TITLE
PN-17943: letto il commandResult.resultCode di lollipopAuthorizer nel…

### DIFF
--- a/src/main/java/it/pagopa/pn/lollipop/client/filter/LollipopWebFilter.java
+++ b/src/main/java/it/pagopa/pn/lollipop/client/filter/LollipopWebFilter.java
@@ -169,6 +169,11 @@ public class LollipopWebFilter implements OrderedWebFilter {
         LollipopConsumerCommand command = consumerCommandBuilder.createCommand(consumerRequest);
         CommandResult commandResult = command.doExecute();
 
+        String resultLollipopAuthorizer = headerParams.get("x-authorizer-result-code");
+        String resultCodeLollipopClient = commandResult.getResultCode();
+        if(resultLollipopAuthorizer != null && resultCodeLollipopClient != null && !resultLollipopAuthorizer.equalsIgnoreCase(resultCodeLollipopClient))
+            log.warn("Tracciatura eventi di validazione incongruenti - resultLollipopAuthorizer: {}, - resultCodeLollipopClient: {}" ,resultLollipopAuthorizer, resultCodeLollipopClient);
+
         if (!commandResult.getResultCode().equals(VERIFICATION_SUCCESS_CODE)) {
             exchange.getResponse().setStatusCode(HttpStatus.BAD_REQUEST);
             log.warn("Lollipop auth response={}, detail={}", commandResult.getResultCode(), commandResult.getResultMessage());


### PR DESCRIPTION
… header e tracciato la dove diverso dal resulCode di lollipopClient